### PR TITLE
Historyfiltration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/launch.json


### PR DESCRIPTION
This Go program fetches command history from the .zsh_history file. It accepts an optional -n flag to specify the number of history items to retrieve. The program warns the user and asks for confirmation before fetching any history, whether it's the entire history or a limited number of entries. If confirmed, it either displays the entire history or the last n entries, depending on the user's input. The code handles various edge cases and provides clear feedback to the user throughout the process.