### PR TITLE
idk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
+# Ignore all
+*
+
+# Unignore all with extensions
+!*.*
+
+# Unignore all dirs
+!*/
+
 .vscode/launch.json

--- a/agents/shellhistory/main.go
+++ b/agents/shellhistory/main.go
@@ -11,21 +11,31 @@ func Run() {
 	// Set default limit to 10
 	n := flag.Int("n", 10, "Number of history items to fetch (default: 10)")
 	flag.Parse()
+	shellpath := os.Getenv("SHELL")
+	shellarr := strings.Split(string(shellpath), "/")
+	shell := shellarr[len(shellarr)-1]
+	var HistoryFile string
 
-	zshHistoryFile := os.Getenv("HOME") + "/.zsh_history"
+	if shell == "zsh" {
+		HistoryFile = os.Getenv("HOME") + "/.zsh_history"
+	} else if shell == "bash" {
+		HistoryFile = os.Getenv("HOME") + "/.bash_history"
+	} else if shell == "fish" {
+		HistoryFile = os.Getenv("HOME") + "/.local/share/fish/fish_history"
+	}
 
 	// If n is <= 0, default to 10
 	if *n <= 0 {
 		*n = 10
 	}
 
-	printLimitedHistory(zshHistoryFile, *n)
+	printLimitedHistory(HistoryFile, *n, shell)
 }
 
-func printLimitedHistory(filename string, n int) {
+func printLimitedHistory(filename string, n int, shell string) {
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		fmt.Println("Error reading .zsh_history file:", err)
+		fmt.Printf("Error reading %s shell history file:\n%s\n", shell, err)
 		return
 	}
 	lines := strings.Split(string(content), "\n")
@@ -33,7 +43,7 @@ func printLimitedHistory(filename string, n int) {
 	if start < 0 {
 		start = 0
 	}
-	fmt.Printf("Last %d lines of .zsh_history file:\n", n)
+	fmt.Printf("Last %d lines of %s history file:\n", n, shell)
 	for _, line := range lines[start:] {
 		fmt.Println(line)
 	}

--- a/agents/shellhistory/main.go
+++ b/agents/shellhistory/main.go
@@ -11,31 +11,21 @@ func Run() {
 	// Set default limit to 10
 	n := flag.Int("n", 10, "Number of history items to fetch (default: 10)")
 	flag.Parse()
-	shellpath := os.Getenv("SHELL")
-	shellarr := strings.Split(string(shellpath), "/")
-	shell := shellarr[len(shellarr)-1]
-	var HistoryFile string
-
-	if shell == "zsh" {
-		HistoryFile = os.Getenv("HOME") + "/.zsh_history"
-	} else if shell == "bash" {
-		HistoryFile = os.Getenv("HOME") + "/.bash_history"
-	} else if shell == "fish" {
-		HistoryFile = os.Getenv("HOME") + "/.local/share/fish/fish_history"
-	}
+		var HistoryFile string
+		HistoryFile = os.Getenv("HOME") + "/.boring_history"
 
 	// If n is <= 0, default to 10
 	if *n <= 0 {
 		*n = 10
 	}
 
-	printLimitedHistory(HistoryFile, *n, shell)
+	printLimitedHistory(HistoryFile, *n)
 }
 
-func printLimitedHistory(filename string, n int, shell string) {
+func printLimitedHistory(filename string, n int) {
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		fmt.Printf("Error reading %s shell history file:\n%s\n", shell, err)
+		fmt.Printf("Error reading shell history file:\n%s\n", err)
 		return
 	}
 	lines := strings.Split(string(content), "\n")
@@ -43,7 +33,7 @@ func printLimitedHistory(filename string, n int, shell string) {
 	if start < 0 {
 		start = 0
 	}
-	fmt.Printf("Last %d lines of %s history file:\n", n, shell)
+	fmt.Printf("Last %d lines of history file:\n", n)
 	for _, line := range lines[start:] {
 		fmt.Println(line)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module os-scrapper
+module os-scraper
 
 go 1.24.1

--- a/runner.go
+++ b/runner.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 
-	"os-scrapper/agents/RunningServicesAndDaemons"
-	"os-scrapper/agents/env_info"
-	"os-scrapper/agents/kernel_probe"
-	"os-scrapper/agents/osinfo"
-	"os-scrapper/agents/shellhistory"
-	"os-scrapper/agents/shellinfo"
+	"os-scraper/agents/RunningServicesAndDaemons"
+	"os-scraper/agents/env_info"
+	"os-scraper/agents/kernel_probe"
+	"os-scraper/agents/osinfo"
+	"os-scraper/agents/shellhistory"
+	"os-scraper/agents/shellinfo"
 )
 
 func main() {


### PR DESCRIPTION
improved shellhistory module (now it can recognize bash, zsh, and fish)

why does the binary come out as os-scrapper again?

made .gitignore ignore all binaries (simply)